### PR TITLE
Remove EAV relation in add-update operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Add #PAC-89: Add debug email command + DebugSendPlugin
 * Add functionality to also parse JSON configuration in extension libraries
+* Add #PAC-57: "--empty-attribute-value-constant" for deleting dedicated attribute values via import by setting a configurable value.
 
 # Version 11.0.1
 

--- a/src/Command/AbstractImportCommand.php
+++ b/src/Command/AbstractImportCommand.php
@@ -76,7 +76,8 @@ abstract class AbstractImportCommand extends Command
              ->addOption(InputOptionKeysInterface::SINGLE_TRANSACTION, null, InputOption::VALUE_REQUIRED, 'Whether or not the import should be wrapped within a single transaction')
              ->addOption(InputOptionKeysInterface::PARAMS, null, InputOption::VALUE_REQUIRED, 'Additional options passed as a string (MUST have the same format as the used configuration file has)')
              ->addOption(InputOptionKeysInterface::PARAMS_FILE, null, InputOption::VALUE_REQUIRED, 'Additional options passed as pathname')
-             ->addOption(InputOptionKeysInterface::MOVE_FILES_PREFIX, null, InputOption::VALUE_REQUIRED, 'Prefix of the files to move (defaults to the prefix of the first of the first plugin subject)');
+             ->addOption(InputOptionKeysInterface::MOVE_FILES_PREFIX, null, InputOption::VALUE_REQUIRED, 'Prefix of the files to move (defaults to the prefix of the first of the first plugin subject)')
+             ->addOption(InputOptionKeysInterface::EMPTY_ATTRIBUTE_VALUE_CONSTANT, null, InputOption::VALUE_REQUIRED, 'Value to define empty value to remove EAV attributes values in categories, products and customers');
     }
 
     /**

--- a/src/Command/InputOptionKeys.php
+++ b/src/Command/InputOptionKeys.php
@@ -72,7 +72,9 @@ class InputOptionKeys extends \ArrayObject implements InputOptionKeysInterface
                 InputOptionKeysInterface::CACHE_ENABLED,
                 InputOptionKeysInterface::MOVE_FILES_PREFIX,
                 InputOptionKeysInterface::CUSTOM_CONFIGURATION_DIR,
-                InputOptionKeysInterface::RENDER_VALIDATION_ISSUES
+                InputOptionKeysInterface::RENDER_VALIDATION_ISSUES,
+                InputOptionKeysInterface::EMPTY_ATTRIBUTE_VALUE_CONSTANT
+
             ),
             $inputOptionKeys
         );


### PR DESCRIPTION
Default attribute value like Magento import with `__EMPTY__VALUE__`